### PR TITLE
Added Dockerized support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ node_modules
 target
 scratch
 *.iml
+bin/*
+lib/*
+m2_cache/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3-jdk-8
+
+ARG GOSU_VERSION=1.9
+ARG GOSU_DOWNLOAD_URL="https://github.com/tianon/gosu/releases/download/${GOSU_VERSION}/gosu-amd64"
+RUN curl -o gosu -fsSL "$GOSU_DOWNLOAD_URL" > gosu-amd64 \
+ && mv gosu /usr/bin/gosu \
+ && chmod +x /usr/bin/gosu
+
+RUN mkdir -p /usr/src/app
+WORKDIR /usr/src/app

--- a/README.md
+++ b/README.md
@@ -11,7 +11,9 @@ Installation
 
 ```
 git clone <this project>
-mvn package
+docker-compose run grib2json ./build
+
+export PATH=$PATH:/path/to/this/dir/bin
 ```
 
 This creates a .tar.gz in the target directory. Unzip and untar the package in a location of choice.

--- a/build
+++ b/build
@@ -1,0 +1,10 @@
+#!/usr/bin/env bash
+
+set -ux
+mvn package
+tar -xvzf target/grib2json-0.8.0-SNAPSHOT.tar.gz
+cp grib2json-0.8.0-SNAPSHOT/bin/* /usr/src/app/bin
+
+cp grib2json-0.8.0-SNAPSHOT/lib/grib2json-0.8.0-SNAPSHOT.jar /usr/src/app/lib/
+rm -Rf /usr/src/app/grib2json-0.8.0-SNAPSHOT
+rm -Rf /usr/src/app/target

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,12 @@
+version: '2'
+services:
+    grib2json:
+        container_name: grib2json
+        build:
+            context: .
+            dockerfile: Dockerfile
+        volumes:
+          - .:/usr/src/app
+          - ./m2_cache:/home/temp/.m2
+        working_dir: /usr/src/app
+        entrypoint: ./docker-entrypoint.sh

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#! /bin/sh
+
+set -ux
+export PATH=$PATH:/usr/src/app/bin
+
+TEMP_UID="${TEMP_UID:-1000}"
+useradd -s /bin/false --no-create-home -u ${TEMP_UID} temp
+exec gosu temp $@


### PR DESCRIPTION
To make it easier for myself, since I do not have maven etc. installed on my machine, I have created a easy to run Docker for this repo. Thus making it easy to run the grib2json utility without all the dependencies installed on my machine.

I do how-ever get errors on my machine in running the grib2json util, even with the dependencies installed on my machine. Would like some input regarding why the exception is thrown.