### PR TITLE
Fix Unidata repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,7 +49,7 @@
         <repository>
             <id>unidata</id>
             <name>THREDDS</name>
-            <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata/</url>
+            <url>https://artifacts.unidata.ucar.edu/content/repositories/unidata-releases/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
The current build fails to find some dependencies when running `mvn package`. Updating the repo link to `unidata-releases` fixes this.